### PR TITLE
add in python3-dev

### DIFF
--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -45,11 +45,11 @@ Step 1: Installing The Littlest JupyterHub
 #. Using a terminal program, SSH into your server. This should give you a prompt where you can
    type commands.
 
-#. Make sure you have ``python3``, ``curl`` and ``git`` installed.
+#. Make sure you have ``python3``, ``python3-dev``, ``curl`` and ``git`` installed.
 
    .. code::
 
-      sudo apt install python3 git curl
+      sudo apt install python3 python3-dev git curl
 
 #. Copy the text below, and paste it into the terminal. Replace
    ``<admin-user-name>`` with the name of the first **admin user** for this


### PR DESCRIPTION
When following these instructions I had a failure of:
```
In file included from src/docstrings.c:4:0:
    src/pycurl.h:4:10: fatal error: Python.h: No such file or directory
     #include <Python.h>
              ^~~~~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

To resolve it I needed to install python3-dev

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->